### PR TITLE
Fix path expansion for repo paths on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+Gitfile

--- a/gitfile/gitfile.go
+++ b/gitfile/gitfile.go
@@ -118,7 +118,8 @@ func runGitCmd(args []string) {
 
 func runCmd(cmd string, args []string) {
 	fmt.Println(strings.Join(append([]string{cmd}, args...), " "))
-	out, err := exec.Command(cmd, args...).Output()
+	fmt.Println("UGHG")
+	out, err := exec.Command("sh", "-c", strings.Join(append([]string{cmd}, args...), " ")).Output()
 	check(err)
 	fmt.Printf("%s", out)
 }

--- a/gitfile/gitfile.go
+++ b/gitfile/gitfile.go
@@ -117,9 +117,9 @@ func runGitCmd(args []string) {
 }
 
 func runCmd(cmd string, args []string) {
-	fmt.Println(strings.Join(append([]string{cmd}, args...), " "))
-	fmt.Println("UGHG")
-	out, err := exec.Command("sh", "-c", strings.Join(append([]string{cmd}, args...), " ")).Output()
+	fullCmd := strings.Join(append([]string{cmd}, args...), " ")
+	fmt.Println(fullCmd)
+	out, err := exec.Command("sh", "-c", "'" + fullCmd + "'").Output()
 	check(err)
 	fmt.Printf("%s", out)
 }

--- a/gitfile/gitfile.go
+++ b/gitfile/gitfile.go
@@ -43,7 +43,13 @@ func addRepoDefaults(repos []repo) {
 		if repos[i].Branch == "" && repos[i].Tag == "" && repos[i].Commit == "" {
 			repos[i].Branch = "master"
 		}
+		repos[i].Path = expandPath(repos[i].Path)
 	}
+}
+
+func expandPath(path string) string {
+	newPath := execCmd("printf " + path)
+	return newPath
 }
 
 func updateRepos(repos []repo) {
@@ -116,12 +122,18 @@ func runGitCmd(args []string) {
 	runCmd("git", args)
 }
 
-func runCmd(cmd string, args []string) {
+func runCmd(cmd string, args []string) string {
 	fullCmd := strings.Join(append([]string{cmd}, args...), " ")
 	fmt.Println(fullCmd)
-	out, err := exec.Command("sh", "-c", "'" + fullCmd + "'").Output()
+	out := execCmd(fullCmd)
+	fmt.Printf("%s\n", out)
+	return out
+}
+
+func execCmd(fullCmd string) string {
+	out, err := exec.Command("bash", "-c", fullCmd).Output()
 	check(err)
-	fmt.Printf("%s", out)
+  return fmt.Sprintf("%s", out)
 }
 
 func parseRepoDir(repoUrl string) (gitDir string) {


### PR DESCRIPTION
Use `bash` to execute commands so that paths expand properly, and eager expand repo paths so that checking directory existence works
